### PR TITLE
Fixed deployment on Raspberry Pi

### DIFF
--- a/src/main/java/org/citopt/connde/service/NetworkService.java
+++ b/src/main/java/org/citopt/connde/service/NetworkService.java
@@ -57,7 +57,7 @@ public class NetworkService {
         /*
         Resolved IP address is still useless
         Last option: resolve the IP address from host name
-         */
+        */
 
         //Resolve host name
         String hostName = InetAddress.getLocalHost().getHostName();
@@ -66,13 +66,13 @@ public class NetworkService {
         List<String> numberBlocks = new ArrayList<>();
 
         //Find all number blocks
-        while(m.find()){
+        while (m.find()) {
             String numberBlock = m.group();
             numberBlocks.add(numberBlock);
         }
 
         //At least four blocks are required
-        if(numberBlocks.size() < 4){
+        if (numberBlocks.size() < 4) {
             return null;
         }
 
@@ -80,9 +80,9 @@ public class NetworkService {
         StringBuilder ipAddressBuilder = new StringBuilder();
 
         //Take the last four number blocks
-        for(int i = (numberBlocks.size() - 4); i < numberBlocks.size(); i++){
+        for (int i = (numberBlocks.size() - 4); i < numberBlocks.size(); i++) {
             //Add number block separator
-            if(ipAddressBuilder.length() > 0){
+            if (ipAddressBuilder.length() > 0) {
                 ipAddressBuilder.append(".");
             }
 

--- a/src/main/java/org/citopt/connde/service/NetworkService.java
+++ b/src/main/java/org/citopt/connde/service/NetworkService.java
@@ -90,7 +90,7 @@ public class NetworkService {
             ipAddressBuilder.append(numberBlocks.get(i));
         }
 
-        return ipAddress;
+        return ipAddressBuilder.toString();
     }
 
     /**

--- a/src/main/java/org/citopt/connde/service/NetworkService.java
+++ b/src/main/java/org/citopt/connde/service/NetworkService.java
@@ -1,8 +1,13 @@
 package org.citopt.connde.service;
 
+import org.citopt.connde.util.Validation;
 import org.springframework.stereotype.Component;
 
 import java.net.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Network service that provides basic network-related features.
@@ -11,6 +16,9 @@ import java.net.*;
  */
 @Component
 public class NetworkService {
+
+    private static final Pattern REGEX_IP_FROM_HOSTNAME = Pattern.compile("\\d{1,3}");
+
     /**
      * Retrieves the own local IP address of the device this application is currently running on. Works even with
      * multiple available network interfaces.     *
@@ -23,7 +31,7 @@ public class NetworkService {
         String ipAddress = Inet4Address.getLocalHost().getHostAddress();
 
         //Check if the resolved address may be correct
-        if ((!ipAddress.equals("127.0.0.1")) && (!ipAddress.equals("localhost"))) {
+        if (isIPAddressUseful(ipAddress)) {
             return ipAddress;
         }
 
@@ -41,6 +49,65 @@ public class NetworkService {
         ipAddress = socket.getLocalAddress().getHostAddress();
         socket.close();
 
+        //Check if the resolved address may be correct
+        if (isIPAddressUseful(ipAddress)) {
+            return ipAddress;
+        }
+
+        /*
+        Resolved IP address is still useless
+        Last option: resolve the IP address from host name
+         */
+
+        //Resolve host name
+        String hostName = InetAddress.getLocalHost().getHostName();
+        Matcher m = REGEX_IP_FROM_HOSTNAME.matcher(hostName);
+
+        List<String> numberBlocks = new ArrayList<>();
+
+        //Find all number blocks
+        while(m.find()){
+            String numberBlock = m.group();
+            numberBlocks.add(numberBlock);
+        }
+
+        //At least four blocks are required
+        if(numberBlocks.size() < 4){
+            return null;
+        }
+
+        //String builder for putting together the ip address
+        StringBuilder ipAddressBuilder = new StringBuilder();
+
+        //Take the last four number blocks
+        for(int i = (numberBlocks.size() - 4); i < numberBlocks.size(); i++){
+            //Add number block separator
+            if(ipAddressBuilder.length() > 0){
+                ipAddressBuilder.append(".");
+            }
+
+            //Append number block
+            ipAddressBuilder.append(numberBlocks.get(i));
+        }
+
         return ipAddress;
+    }
+
+    /**
+     * Checks whether a given IP address is valid and makes sense so it can be used for deployment.
+     * Considered as useless IP addresses are "127.0.0.1", "localhost" and IP addresses starting
+     * with "10." (internal OpenStack IP addresses).
+     *
+     * @param ipAddress The IP address to check
+     * @return True, if the IP address is useful; false otherwise
+     */
+    private boolean isIPAddressUseful(String ipAddress) {
+        //Check format
+        if (!Validation.isValidIPAddress(ipAddress)) {
+            return false;
+        }
+
+        //Validation check
+        return (!ipAddress.equals("127.0.0.1")) && (!ipAddress.equals("localhost")) && (!ipAddress.startsWith("10."));
     }
 }

--- a/src/main/java/org/citopt/connde/service/NetworkService.java
+++ b/src/main/java/org/citopt/connde/service/NetworkService.java
@@ -108,6 +108,6 @@ public class NetworkService {
         }
 
         //Validation check
-        return (!ipAddress.equals("127.0.0.1")) && (!ipAddress.equals("localhost")) && (!ipAddress.startsWith("10."));
+        return (!ipAddress.equals("127.0.0.1")) && (!ipAddress.equals("localhost")) && (!ipAddress.startsWith("10.0."));
     }
 }

--- a/src/main/java/org/citopt/connde/service/deploy/SSHDeployer.java
+++ b/src/main/java/org/citopt/connde/service/deploy/SSHDeployer.java
@@ -39,7 +39,7 @@ public class SSHDeployer {
     private static final Logger LOGGER = Logger.getLogger(SSHDeployer.class.getName());
 
     //Deployment location on remote devices
-    private static final String DEPLOY_DIR = "~/scripts";
+    private static final String DEPLOY_DIR = "$HOME/scripts";
     private static final String DEPLOY_DIR_PREFIX = "connde";
 
     //Port of the remote devices to use for SSH connections

--- a/src/main/java/org/citopt/connde/service/deploy/SSHDeployer.java
+++ b/src/main/java/org/citopt/connde/service/deploy/SSHDeployer.java
@@ -125,6 +125,11 @@ public class SSHDeployer {
             brokerIP = settings.getBrokerIPAddress();
         }
 
+        //Sanity check
+        if(brokerIP == null){
+            throw new RuntimeException("Unable to resolve IP address of the broker.");
+        }
+
         //Get topic name for the component
         String topicName = component.getTopicName();
 

--- a/src/main/java/org/citopt/connde/web/rest/RestDebugController.java
+++ b/src/main/java/org/citopt/connde/web/rest/RestDebugController.java
@@ -1,0 +1,34 @@
+package org.citopt.connde.web.rest;
+
+import org.citopt.connde.RestConfiguration;
+import org.citopt.connde.service.NetworkService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST Controller for debugging.
+ *
+ * @author Jan
+ */
+@RestController
+@RequestMapping(RestConfiguration.BASE_PATH)
+public class RestDebugController {
+
+    @Autowired
+    private NetworkService networkService;
+
+    @RequestMapping(value = "/debug/ip", method = RequestMethod.GET)
+    public ResponseEntity<String> getSettings() {
+        String brokerIP = null;
+        try {
+            brokerIP = networkService.getOwnIPAddress();
+        } catch (Exception e) {
+            return new ResponseEntity<String>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        return new ResponseEntity<String>(brokerIP, HttpStatus.OK);
+    }
+}


### PR DESCRIPTION
By replacing "~" with "$HOME", deployment of an adapter on the raspberry pi is now possible again. Does still work on VMs as well.

Closes #48