### PR TITLE
Optional adapter description

### DIFF
--- a/src/main/java/org/citopt/connde/domain/adapter/AdapterValidator.java
+++ b/src/main/java/org/citopt/connde/domain/adapter/AdapterValidator.java
@@ -38,10 +38,6 @@ public class AdapterValidator implements Validator {
                 errors, "name", "adapter.name.empty",
                 "The name cannot be empty!");
 
-        ValidationUtils.rejectIfEmptyOrWhitespace(
-                errors, "description", "adapter.description.empty",
-                "The description cannot be empty!");
-
         if (!adapter.hasRoutines()) {
             errors.rejectValue("routines", "adapter.routines.empty",
                     "Routine files must be provided.");


### PR DESCRIPTION
The adapter description is no longer mandatory when creating a new adapter.
Closes #57