### PR TITLE
Removal of redundant mac address field

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ accept: application/json
   "name": "Raspberry Pi",
   "macAddress": "123456789067",
   "ipAddress": "192.168.0.34",
-  "formattedMacAddress": "12-34-56-78-90-67",
   "username": "pi",
   "rsaKey": "-----BEGIN RSA PRIVATE KEY-----\nMIIEogIBAAKC...\n-----END RSA PRIVATE KEY-----"
 }
@@ -154,7 +153,6 @@ PUT /api/devices/596c7a7d4f0c58688e5aa6b1 HTTP/1.1
   "name": "Raspberry Pi",
   "macAddress": "127556789067",
   "ipAddress": "192.168.0.75",
-  "formattedMacAddress": "12-75-56-78-90-67",
   "username": "pi",
   "rsaKey": "-----BEGIN RSA PRIVATE KEY-----\nMIIEogIBAAKC...\n-----END RSA PRIVATE KEY-----"
 }

--- a/src/main/resources/static/js/controllers/devices/DeviceListController.js
+++ b/src/main/resources/static/js/controllers/devices/DeviceListController.js
@@ -1,91 +1,91 @@
 /* global app */
 
 app.controller('DeviceListController',
-  ['$scope', '$controller', 'DeviceService', 'deviceList', 'addDevice', 'deleteDevice', 'ComponentTypeService',
-    function($scope, $controller, DeviceService, deviceList, addDevice, deleteDevice, ComponentTypeService) {
-      var vm = this;
+    ['$scope', '$controller', 'DeviceService', 'deviceList', 'addDevice', 'deleteDevice', 'ComponentTypeService',
+        function ($scope, $controller, DeviceService, deviceList, addDevice, deleteDevice, ComponentTypeService) {
+            var vm = this;
 
-      (function initController() {
-        loadDeviceTypes();
-      })();
+            (function initController() {
+                loadDeviceTypes();
+            })();
 
-      for (var i in deviceList) {
-        deviceList[i].formattedMacAddress =
-          DeviceService.formatMacAddress(deviceList[i].macAddress);
-      }
-
-      // expose controller ($controller will auto-add to $scope)
-      angular.extend(vm, {
-        deviceListCtrl: $controller('ItemListController as deviceListCtrl', {
-          $scope: $scope,
-          list: deviceList
-        }),
-        addDeviceCtrl: $controller('AddItemController as addDeviceCtrl', {
-          $scope: $scope,
-          addItem: function(data) {
-            var deviceObject = {};
-
-            for (var property in data) {
-              if (data.hasOwnProperty(property)) {
-                deviceObject[property] = data[property];
-              }
+            for (var i in deviceList) {
+                deviceList[i].formattedMacAddress =
+                    DeviceService.formatMacAddress(deviceList[i].macAddress);
             }
-            delete deviceObject.formattedMacAddress;
-            deviceObject.macAddress = DeviceService.normalizeMacAddress(data.formattedMacAddress);
 
-            return addDevice(deviceObject);
-          }
-        }),
-        deleteDeviceCtrl: $controller('DeleteItemController as deleteDeviceCtrl', {
-          $scope: $scope,
-          deleteItem: function(data) {
-            // get ID here
-            return deleteDevice(data);
-          }
-        })
-      });
+            // expose controller ($controller will auto-add to $scope)
+            angular.extend(vm, {
+                deviceListCtrl: $controller('ItemListController as deviceListCtrl', {
+                    $scope: $scope,
+                    list: deviceList
+                }),
+                addDeviceCtrl: $controller('AddItemController as addDeviceCtrl', {
+                    $scope: $scope,
+                    addItem: function (data) {
+                        var deviceObject = {};
 
-      // $watch 'addItem' result and add to 'itemList'
-      $scope.$watch(
-        function() {
-          // value being watched
-          return vm.addDeviceCtrl.result;
-        },
-        function() {
-          // callback
-          console.log('addDeviceCtrl.result modified.');
+                        for (var property in data) {
+                            if (data.hasOwnProperty(property)) {
+                                deviceObject[property] = data[property];
+                            }
+                        }
+                        delete deviceObject.formattedMacAddress;
+                        deviceObject.macAddress = DeviceService.normalizeMacAddress(data.formattedMacAddress);
 
-          var data = vm.addDeviceCtrl.result;
-          if (data) {
-            data.formattedMacAddress = DeviceService.formatMacAddress(data.macAddress);
-            vm.deviceListCtrl.pushItem(data);
-          }
+                        return addDevice(deviceObject);
+                    }
+                }),
+                deleteDeviceCtrl: $controller('DeleteItemController as deleteDeviceCtrl', {
+                    $scope: $scope,
+                    deleteItem: function (data) {
+                        // get ID here
+                        return deleteDevice(data);
+                    }
+                })
+            });
+
+            // $watch 'addItem' result and add to 'itemList'
+            $scope.$watch(
+                function () {
+                    // value being watched
+                    return vm.addDeviceCtrl.result;
+                },
+                function () {
+                    // callback
+                    console.log('addDeviceCtrl.result modified.');
+
+                    var data = vm.addDeviceCtrl.result;
+                    if (data) {
+                        data.formattedMacAddress = DeviceService.formatMacAddress(data.macAddress);
+                        vm.deviceListCtrl.pushItem(data);
+                    }
+                }
+            );
+
+            // $watch 'deleteItem' result and remove from 'itemList'
+            $scope.$watch(
+                function () {
+                    // value being watched
+                    return vm.deleteDeviceCtrl.result;
+                },
+                function () {
+                    var id = vm.deleteDeviceCtrl.result;
+
+                    vm.deviceListCtrl.removeItem(id);
+                }
+            );
+
+            function loadDeviceTypes() {
+                ComponentTypeService.GetByComponent('DEVICE')
+                    .then(function (response) {
+                        if (response.success) {
+                            vm.deviceTypes = response.data;
+                        } else {
+                            console.log("Error loading device types!");
+                        }
+                    });
+            };
+
         }
-      );
-
-      // $watch 'deleteItem' result and remove from 'itemList'
-      $scope.$watch(
-        function() {
-          // value being watched
-          return vm.deleteDeviceCtrl.result;
-        },
-        function() {
-          var id = vm.deleteDeviceCtrl.result;
-
-          vm.deviceListCtrl.removeItem(id);
-        }
-      );
-
-      function loadDeviceTypes() {
-        ComponentTypeService.GetByComponent('DEVICE')
-          .then(function(response) {
-            if (response.success) {
-              vm.deviceTypes = response.data;
-            } else {
-              console.log("Error loading device types!");
-            }
-          });
-      };
-
-    }
-  ]);
+    ]);

--- a/src/main/resources/static/js/controllers/devices/DeviceListController.js
+++ b/src/main/resources/static/js/controllers/devices/DeviceListController.js
@@ -23,8 +23,17 @@ app.controller('DeviceListController',
         addDeviceCtrl: $controller('AddItemController as addDeviceCtrl', {
           $scope: $scope,
           addItem: function(data) {
-            data.macAddress = DeviceService.normalizeMacAddress(data.formattedMacAddress);
-            return addDevice(data);
+            var deviceObject = {};
+
+            for (var property in data) {
+              if (data.hasOwnProperty(property)) {
+                deviceObject[property] = data[property];
+              }
+            }
+            delete deviceObject.formattedMacAddress;
+            deviceObject.macAddress = DeviceService.normalizeMacAddress(data.formattedMacAddress);
+
+            return addDevice(deviceObject);
           }
         }),
         deleteDeviceCtrl: $controller('DeleteItemController as deleteDeviceCtrl', {


### PR DESCRIPTION
The field "formattedMacAddress" is no longer sent to the backend when creating a new device. Further adjustments (except for the Readme) were not necessary, because this field has never been processed on server side.

Closes #61