### PR TITLE
Deletion of value logs

### DIFF
--- a/src/main/resources/static/js/controllers/components/ComponentDetailsController.js
+++ b/src/main/resources/static/js/controllers/components/ComponentDetailsController.js
@@ -225,10 +225,51 @@ app.controller('ComponentDetailsController',
 
 
             /**
+             * [Public]
+             * Asks the user if he really wants to delete all value logs for the current component. If this is the case,
+             * the deletion is executed by creating the corresponding server request.
+             */
+            function deleteValueLogs() {
+                /**
+                 * Executes the deletion of the value logs by performing the server request.
+                 */
+                function executeDeletion() {
+                    ComponentService.deleteValueLogs(COMPONENT_ID, COMPONENT_TYPE).then(function (response) {
+                        //Update historical chart and stats
+                        $scope.historicalChartApi.updateChart();
+                        $scope.valueLogStatsApi.updateStats();
+
+                        NotificationService.notify("Value logs were deleted successfully.", "success");
+                    }, function (response) {
+                        NotificationService.notify("Could not delete value logs.", "error");
+                    });
+                }
+
+                //Ask the user to confirm the deletion
+                return Swal.fire({
+                    title: 'Delete value data',
+                    type: 'warning',
+                    html: "Are you sure you want to delete all value data that has been recorded so far for this " +
+                        "component? This action cannot be undone.",
+                    showCancelButton: true,
+                    confirmButtonText: 'Delete',
+                    confirmButtonClass: 'bg-red',
+                    focusConfirm: false,
+                    cancelButtonText: 'Cancel'
+                }).then(function (result) {
+                    //Check if the user confirmed the deletion
+                    if (result.value) {
+                        executeDeletion();
+                    }
+                });
+            }
+
+
+            /**
              * [Private]
              * Initializes the value log stats display.
              */
-            function initValueLogStats(){
+            function initValueLogStats() {
                 /**
                  * Function that is called when the value log stats display loads something
                  */
@@ -253,7 +294,7 @@ app.controller('ComponentDetailsController',
                  * Function that is used by the value log stats display to retrieve the statistics in a specific unit
                  * from the server.
                  */
-                function getStats(unit){
+                function getStats(unit) {
                     return ComponentService.getValueLogStats(COMPONENT_ID, COMPONENT_TYPE_URL, unit).then(function (response) {
                         //Success, pass statistics data
                         return response.data;
@@ -404,7 +445,8 @@ app.controller('ComponentDetailsController',
                 updateDeviceState: updateDeviceState,
                 onDisplayUnitChange: onDisplayUnitChange,
                 deploy: deploy,
-                undeploy: undeploy
+                undeploy: undeploy,
+                deleteValueLogs: deleteValueLogs
             });
 
         }]

--- a/src/main/resources/static/js/services/ComponentService.js
+++ b/src/main/resources/static/js/services/ComponentService.js
@@ -15,7 +15,7 @@ app.factory('ComponentService', ['$http', '$resource', '$q', 'ENDPOINT_URI',
         //URL suffix under which the deployment state of a certain component can be retrieved
         const URL_GET_VALUE_LOG_STATS_SUFFIX = '/stats/';
         //URL suffix under which the value logs of a certain component can be retrieved
-        const URL_GET_VALUE_LOGS_SUFFIX = '/valueLogs';
+        const URL_VALUE_LOGS_SUFFIX = '/valueLogs';
 
 
         /**
@@ -84,13 +84,28 @@ app.factory('ComponentService', ['$http', '$resource', '$q', 'ENDPOINT_URI',
             }
 
             //Execute request
-            return $http.get(URL_PREFIX + component + 's/' + componentId + URL_GET_VALUE_LOGS_SUFFIX, {
+            return $http.get(URL_PREFIX + component + 's/' + componentId + URL_VALUE_LOGS_SUFFIX, {
                 params: parameters
             }).then(function (response) {
                 //Process received logs in order to be able to display them in a chart
                 return processValueLogs(response.data.content);
             });
         }
+
+
+        /**
+         * [Public]
+         * Performs a server request in order to delete all recorded value logs of a certain component.
+         *
+         * @param componentId The id of the component whose value logs are supposed to be deleted
+         * @param component The type of the component
+         * @returns {*}
+         */
+        function deleteValueLogs(componentId, component) {
+            //Execute request
+            return $http.delete(URL_PREFIX + component + 's/' + componentId + URL_VALUE_LOGS_SUFFIX);
+        }
+
 
         /**
          * [Public]
@@ -160,6 +175,7 @@ app.factory('ComponentService', ['$http', '$resource', '$q', 'ENDPOINT_URI',
             getComponentState: getComponentState,
             getValueLogStats: getValueLogStats,
             getValueLogs: getValueLogs,
+            deleteValueLogs: deleteValueLogs,
             isDeployed: function (url) {
                 return $http({
                     method: 'GET',

--- a/src/main/resources/static/js/services/MonitoringService.js
+++ b/src/main/resources/static/js/services/MonitoringService.js
@@ -10,7 +10,7 @@ app.factory('MonitoringService', ['$http', '$resource', '$q', 'ENDPOINT_URI', 'C
         const URL_MONITORING_PREFIX = ENDPOINT_URI + '/monitoring/';
         const URL_GET_STATE = ENDPOINT_URI + '/monitoring/state/';
         const URL_GET_VALUE_LOG_STATS = ENDPOINT_URI + '/monitoring/stats/';
-        const URL_GET_VALUE_LOGS_SUFFIX = '/valueLogs';
+        const URL_VALUE_LOGS_SUFFIX = '/valueLogs';
         const URL_ADAPTER_SUFFIX = '?adapter=';
 
         /**
@@ -142,13 +142,38 @@ app.factory('MonitoringService', ['$http', '$resource', '$q', 'ENDPOINT_URI', 'C
             }
 
             //Execute request
-            return $http.get(URL_MONITORING_PREFIX + deviceId + URL_GET_VALUE_LOGS_SUFFIX, {
+            return $http.get(URL_MONITORING_PREFIX + deviceId + URL_VALUE_LOGS_SUFFIX, {
                 params: parameters
             }).then(function (response) {
                 //Process received logs in order to be able to display them in a chart
                 return ComponentService.processValueLogs(response.data.content);
             });
         }
+
+
+        /**
+         * [Public]
+         * Performs a server request in order to delete all recorded value logs of a certain monitoring component.
+         *
+         * @param componentId The id of the component whose value logs are supposed to be deleted
+         * @param component The type of the component
+         * @param deviceId The id of the device that is part of the monitoring component whose value logs
+         * are supposed to be deleted
+         * @param monitoringAdapterId The id of the monitoring adapter that is part of the monitoring component
+         * whose value logs are supposed to be deleted
+         * @returns {*}
+         */
+        function deleteMonitoringValueLogs(deviceId, monitoringAdapterId) {
+            var parameters = {
+                adapter: monitoringAdapterId
+            };
+
+            //Execute request
+            return $http.delete(URL_MONITORING_PREFIX + deviceId + URL_VALUE_LOGS_SUFFIX, {
+                params: parameters
+            });
+        }
+
 
         /**
          * [Private]
@@ -170,7 +195,8 @@ app.factory('MonitoringService', ['$http', '$resource', '$q', 'ENDPOINT_URI', 'C
             enableMonitoring: enableMonitoring,
             disableMonitoring: disableMonitoring,
             getMonitoringValueLogStats: getMonitoringValueLogStats,
-            getMonitoringValueLogs: getMonitoringValueLogs
+            getMonitoringValueLogs: getMonitoringValueLogs,
+            deleteMonitoringValueLogs: deleteMonitoringValueLogs
         }
     }
 ]);

--- a/src/main/webapp/WEB-INF/views/templates/actuator-id.html
+++ b/src/main/webapp/WEB-INF/views/templates/actuator-id.html
@@ -177,6 +177,11 @@
                                  get-stats="componentDetailsCtrl.valueLogStats.getStats(unit)"
                                  unit="{{componentDetailsCtrl.displayUnit}}">
                 </value-log-stats>
+                <div style="height: 20px"></div>
+                <h4>Delete data</h4>
+                <button class="btn btn-danger waves-effect" ng-click="componentDetailsCtrl.deleteValueLogs()">
+                    Delete all actuator data
+                </button>
             </div>
         </div>
     </div>
@@ -230,3 +235,6 @@
         </div>
     </div>
 </div>
+                
+                
+                

--- a/src/main/webapp/WEB-INF/views/templates/device-id.html
+++ b/src/main/webapp/WEB-INF/views/templates/device-id.html
@@ -179,9 +179,14 @@
                     </h2>
                     <ul class="header-dropdown m-r--5">
                         <li>
-                            <a ng-click="adapter.historicalChartApi.updateChart(); adapter.valueLogStatsApi.updateStats();"
-                               class="clickable">
+                            <a class="clickable"
+                               ng-click="adapter.historicalChartApi.updateChart(); adapter.valueLogStatsApi.updateStats();">
                                 <i class="material-icons">refresh</i>
+                            </a>
+                        </li>
+                        <li>
+                            <a class="clickable" ng-click="adapter.deleteValueLogs()">
+                                <i class="material-icons">delete</i>
                             </a>
                         </li>
                         <li>

--- a/src/main/webapp/WEB-INF/views/templates/sensor-id.html
+++ b/src/main/webapp/WEB-INF/views/templates/sensor-id.html
@@ -177,6 +177,11 @@
                                  get-stats="componentDetailsCtrl.valueLogStats.getStats(unit)"
                                  unit="{{componentDetailsCtrl.displayUnit}}">
                 </value-log-stats>
+                <div style="height: 20px"></div>
+                <h4>Delete data</h4>
+                <button class="btn btn-danger waves-effect" ng-click="componentDetailsCtrl.deleteValueLogs()">
+                    Delete all sensor data
+                </button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This PR enables the deletion of value logs that were recorded for a specific component (actuator, sensor, monitoring component). Deletion requests can be created by clicking on the dedicated icons/buttons in the actuator/sensor/device details pages. A global deletion system (one that deletes all value logs) has not been implemented yet.

Closes #85 