### PR TITLE
Dockerize MBP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Please execute the following steps:
 - Deploy the MBP application on Tomcat by moving the `MBP.war` to the Tomcat `webapps` folder  
 
 Once the installation is completed, the MBP will be available on the URL *http://[MBP-Host]:8080/MBP*.
+
+### Installation using Docker
+There is a [docker container](https://github.com/IPVS-AS/MBP-Docker) available which includes a ready-to-use setup of the MBP application and its dependencies.
     
 ### Tip: Cross-Origin Resource Sharing (CORS)
 


### PR DESCRIPTION
There is now a docker container available in [this repository](https://github.com/IPVS-AS/MBP-Docker) which includes a full setup of the MBP and its dependencies. It seems to work well, however an external MQTT broker needs to be used for retrieving sensor values in most cases, since docker containers are only accessible for the host on which the docker instance is running on. Luckily, we already have an option in the settings that allows switching to an external MQTT broker at runtime.

The container is available in the repository linked above; this PR contains only a small addition to the Readme file in order to link to the Docker repo.

Closes #5 