### PR TITLE
Fix for crash on deletion of rule actions

### DIFF
--- a/src/main/java/org/citopt/connde/web/rest/event_handler/RuleActionEventHandler.java
+++ b/src/main/java/org/citopt/connde/web/rest/event_handler/RuleActionEventHandler.java
@@ -3,13 +3,11 @@ package org.citopt.connde.web.rest.event_handler;
 import org.citopt.connde.domain.rules.Rule;
 import org.citopt.connde.domain.rules.RuleAction;
 import org.citopt.connde.repository.RuleRepository;
+import org.citopt.connde.service.rules.RuleEngine;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.core.annotation.HandleBeforeDelete;
 import org.springframework.data.rest.core.annotation.RepositoryEventHandler;
 import org.springframework.stereotype.Component;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Event handler for operations that are performed on rule actions.
@@ -21,6 +19,9 @@ public class RuleActionEventHandler {
     @Autowired
     private RuleRepository ruleRepository;
 
+    @Autowired
+    private RuleEngine ruleEngine;
+
     /**
      * Called, when a rule action is supposed to be deleted. This method then takes care of deleting
      * the rules as well that make use of this rule action.
@@ -29,22 +30,21 @@ public class RuleActionEventHandler {
      */
     @HandleBeforeDelete
     public void beforeRuleActionDelete(RuleAction ruleAction) {
-        //Stores all affected rules
-        List<Rule> affectedRules = new ArrayList<>();
-
         //Get rules that are affected by this action
         for (Rule rule : ruleRepository.findAll()) {
             //Iterate over all actions of this rule
             for (RuleAction ruleActionCheck : rule.getActions()) {
                 //Compare current rule action with the affected one
                 if (ruleActionCheck.equals(ruleAction)) {
-                    affectedRules.add(rule);
+                    //Disable rule
+                    ruleEngine.disableRule(rule);
+
+                    //Delete rule
+                    ruleRepository.delete(rule);
+
                     break;
                 }
             }
         }
-
-        //Delete all affected rules
-        ruleRepository.delete(affectedRules);
     }
 }

--- a/src/main/java/org/citopt/connde/web/rest/event_handler/RuleActionEventHandler.java
+++ b/src/main/java/org/citopt/connde/web/rest/event_handler/RuleActionEventHandler.java
@@ -9,6 +9,8 @@ import org.springframework.data.rest.core.annotation.HandleBeforeDelete;
 import org.springframework.data.rest.core.annotation.RepositoryEventHandler;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 /**
  * Event handler for operations that are performed on rule actions.
  */
@@ -32,18 +34,16 @@ public class RuleActionEventHandler {
     public void beforeRuleActionDelete(RuleAction ruleAction) {
         //Get rules that are affected by this action
         for (Rule rule : ruleRepository.findAll()) {
-            //Iterate over all actions of this rule
-            for (RuleAction ruleActionCheck : rule.getActions()) {
-                //Compare current rule action with the affected one
-                if (ruleActionCheck.equals(ruleAction)) {
-                    //Disable rule
-                    ruleEngine.disableRule(rule);
+            //Get rule actions of the current rule
+            List<RuleAction> ruleActions = rule.getActions();
 
-                    //Delete rule
-                    ruleRepository.delete(rule);
+            //Check if the affected action is among these rule actions
+            if(ruleActions.contains(ruleAction)){
+                //Disable rule
+                ruleEngine.disableRule(rule);
 
-                    break;
-                }
+                //Delete rule
+                ruleRepository.delete(rule);
             }
         }
     }


### PR DESCRIPTION
Fixes the application crash that could occur in case a rule action was deleted that is part of an enabled rule. The failure occurred, because the affected rule was deleted, but has not been automatically disabled before. Thus, a reference to the former rule remained in memory of the RuleEngine and an triggered execution of the rule caused the application to crash.

Hopefully closes #216