### PR TITLE
Increase InfluxDB timeout

### DIFF
--- a/src/main/java/org/citopt/connde/InfluxDBConfiguration.java
+++ b/src/main/java/org/citopt/connde/InfluxDBConfiguration.java
@@ -26,6 +26,18 @@ public class InfluxDBConfiguration {
     //Duration time
     private static final String DURATION_TIME = "150d";
 
+    //Timeouts
+    private static final long CONNECT_TIMEOUT_MINUTES = 1;
+    private static final long READ_TIMEOUT_MINUTES = 1;
+    private static final long WRITE_TIMEOUT_SECONDS = 5;
+
+    //Retry on connection loss
+    private static final boolean RETRY_ON_CONNECTION_LOSS = true;
+
+    //Use GZIP
+    private static final boolean USE_GZIP = true;
+
+
     /**
      * Creates the InfluxDB bean.
      *
@@ -35,13 +47,20 @@ public class InfluxDBConfiguration {
     public InfluxDB influxDB() {
         //Build HTTP client for InfluxDB
         OkHttpClient.Builder httpClient = new OkHttpClient().newBuilder()
-                .connectTimeout(1, TimeUnit.MINUTES)
-                .readTimeout(1, TimeUnit.MINUTES)
-                .writeTimeout(5, TimeUnit.SECONDS)
-                .retryOnConnectionFailure(true);
+                .connectTimeout(CONNECT_TIMEOUT_MINUTES, TimeUnit.MINUTES)
+                .readTimeout(READ_TIMEOUT_MINUTES, TimeUnit.MINUTES)
+                .writeTimeout(WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .retryOnConnectionFailure(RETRY_ON_CONNECTION_LOSS);
 
         //Connect to the InfluxDB
         InfluxDB influxDB = InfluxDBFactory.connect(URL, httpClient);
+
+        //Enable GZIP if desired
+        if (USE_GZIP) {
+            influxDB.enableGzip();
+        } else {
+            influxDB.disableGzip();
+        }
 
         //Set database, create if it does not exist
         influxDB.query(new Query("CREATE DATABASE " + DATABASE_NAME));

--- a/src/main/java/org/citopt/connde/InfluxDBConfiguration.java
+++ b/src/main/java/org/citopt/connde/InfluxDBConfiguration.java
@@ -37,7 +37,6 @@ public class InfluxDBConfiguration {
     //Use GZIP
     private static final boolean USE_GZIP = false;
 
-
     /**
      * Creates the InfluxDB bean.
      *

--- a/src/main/java/org/citopt/connde/InfluxDBConfiguration.java
+++ b/src/main/java/org/citopt/connde/InfluxDBConfiguration.java
@@ -24,7 +24,7 @@ public class InfluxDBConfiguration {
     public static final String RETENTION_POLICY_NAME = "retentionPolicy";
 
     //Duration time
-    private static final String DURATION_TIME = "150d";
+    private static final String DURATION_TIME = "90d";
 
     //Timeouts
     private static final long CONNECT_TIMEOUT_MINUTES = 1;

--- a/src/main/java/org/citopt/connde/InfluxDBConfiguration.java
+++ b/src/main/java/org/citopt/connde/InfluxDBConfiguration.java
@@ -35,7 +35,7 @@ public class InfluxDBConfiguration {
     private static final boolean RETRY_ON_CONNECTION_LOSS = true;
 
     //Use GZIP
-    private static final boolean USE_GZIP = true;
+    private static final boolean USE_GZIP = false;
 
 
     /**

--- a/src/main/java/org/citopt/connde/InfluxDBConfiguration.java
+++ b/src/main/java/org/citopt/connde/InfluxDBConfiguration.java
@@ -1,12 +1,15 @@
 package org.citopt.connde;
 
 
+import okhttp3.OkHttpClient;
 import org.influxdb.BatchOptions;
 import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDBFactory;
 import org.influxdb.dto.Query;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
 
 @Configuration
 public class InfluxDBConfiguration {
@@ -21,7 +24,7 @@ public class InfluxDBConfiguration {
     public static final String RETENTION_POLICY_NAME = "retentionPolicy";
 
     //Duration time
-    private static final String DURATION_TIME = "365d";
+    private static final String DURATION_TIME = "150d";
 
     /**
      * Creates the InfluxDB bean.
@@ -30,8 +33,15 @@ public class InfluxDBConfiguration {
      */
     @Bean
     public InfluxDB influxDB() {
+        //Build HTTP client for InfluxDB
+        OkHttpClient.Builder httpClient = new OkHttpClient().newBuilder()
+                .connectTimeout(1, TimeUnit.MINUTES)
+                .readTimeout(1, TimeUnit.MINUTES)
+                .writeTimeout(5, TimeUnit.SECONDS)
+                .retryOnConnectionFailure(true);
+
         //Connect to the InfluxDB
-        InfluxDB influxDB = InfluxDBFactory.connect(URL);
+        InfluxDB influxDB = InfluxDBFactory.connect(URL, httpClient);
 
         //Set database, create if it does not exist
         influxDB.query(new Query("CREATE DATABASE " + DATABASE_NAME));

--- a/src/main/java/org/citopt/connde/web/rest/RestValueLogController.java
+++ b/src/main/java/org/citopt/connde/web/rest/RestValueLogController.java
@@ -171,7 +171,7 @@ public class RestValueLogController {
         }
 
         //Try to get unit object from string
-        Unit targetUnit = null;
+        Unit targetUnit;
         try {
             targetUnit = Unit.valueOf(unit);
         } catch (Exception e) {


### PR DESCRIPTION
Specifies and increases the InfluxDB timeout threshold in order to get rid of timeout error messages in sensor view. Additionally decreasees the deletion time of the retention policy to 90 days.

Closes #222 