### PR TITLE
Hotfix for maven pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,16 @@
         </repository>
     </repositories>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>spring-plugins-release</id>
+            <url>https://repo.spring.io/plugins-release</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
         <!-- https://mvnrepository.com/artifact/commons-validator/commons-validator -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,19 +20,9 @@
             </snapshots>
             <id>jcenter-releases</id>
             <name>jcenter</name>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </repository>
     </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>spring-plugins-release</id>
-            <url>https://repo.spring.io/plugins-release</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </pluginRepository>
-    </pluginRepositories>
 
     <dependencies>
         <!-- https://mvnrepository.com/artifact/commons-validator/commons-validator -->


### PR DESCRIPTION
Since January 2020, the JCenter repository denies all requests that use http instead of https. This breaks our current maven build process, because our pom.xml refers to this repository via http.

Closes #233