### PR TITLE
PR-235 Enable removing wrongly uploaded files

### DIFF
--- a/src/main/resources/static/js/controllers/adapters/AdapterListController.js
+++ b/src/main/resources/static/js/controllers/adapters/AdapterListController.js
@@ -19,6 +19,7 @@ app.controller('AdapterListController',
 
             vm.dzRoutinesOptions = {
                 paramName: 'routinesFile',
+                addRemoveLinks: true,
                 maxFilesize: '100',
                 maxFiles: 99
             };
@@ -29,7 +30,11 @@ app.controller('AdapterListController',
                         vm.addAdapterCtrl.item.routineFiles = [];
                     }
                     vm.addAdapterCtrl.item.routineFiles.push(file);
-                }
+                },
+                'removedfile': function(file){
+                  vm.addAdapterCtrl.item.routineFiles.splice(vm.addAdapterCtrl.item.routineFiles.indexOf(file),1);
+                },
+
             };
 
             vm.dzMethods = {};


### PR DESCRIPTION
It enables "removing wrongly" by changing the dropzone's conf and
removing the file from the routineFile array