### PR TITLE
Update MBP client and add symbolic links in operator folders

### DIFF
--- a/resources/operators/README.md
+++ b/resources/operators/README.md
@@ -1,6 +1,7 @@
 # MBP Operators Repository
 
-This folder contains examplary operator scripts that can be deployed onto IoT devices by the MBP. These operators are divided into four categories: 
+This folder contains examplary operator scripts that can be deployed onto IoT devices by the MBP. 
+These operators are divided into four categories: 
 
  - [extraction](extraction) operators: this folder contains operator scripts to bind sensors to the MBP. 
 
@@ -9,6 +10,8 @@ This folder contains examplary operator scripts that can be deployed onto IoT de
  - [monitoring](monitoring) operators: this folder contains operator scripts to monitor IoT devices. 
 
  - [processing](processing) operators: this folder contains operator scripts to execute operations onto IoT devices. 
+
+In order to facilitate the development of such operators, we provide the [mbp_client](mbp_client), a python-based library, which provide functions to connect and communicate to the MBP in a simple manner.  
 
 The MBP enables users to provide their own operators, which can be implemented in any programming language.
 The MBP requires, however, to be provided with specific lifecycle management scripts for the operator (i.e., `install.sh`, `start.sh`, `running.sh`, and `stop.sh`), in order to be able to automate the deployment of the user-defined operators.

--- a/resources/operators/extraction/temperature_stub/README.md
+++ b/resources/operators/extraction/temperature_stub/README.md
@@ -7,13 +7,10 @@ This folder contains operator scripts to simulate the extraction of temperature 
  - a computer running a Linux-based OS, such as a Raspberry Pi or a Laptop running the Ubuntu OS.
 
 ## Operator files 
-
- - `temperature_stub.py`: This python script contains a MQTT client, which publishes the simulated sensor data to a configured topic on the MBP.
- 
- - `install.sh`: This file installs the necessary libraries to run the python script.
- 
- - `start.sh`: This file starts the execution of the python script.
- 
- - `running.sh`: This file checks if the python script is running.
-  
- - `stop.sh`: This file stops the execution of the python script.
+ - `mbp_client.py`: This python script contains the logic to connect and to communicate with the MBP. It abstracts a MQTT client and further configuration steps.  
+ - `entry-file-name`: This file contains solely the name of your main python script including its extension.  
+ - `temperature_stub.py`: This python script simulates sensor data and uses the `mbp_client` to send these data to the MBP.  
+ - `install.sh`: This file installs the necessary libraries to run the `mbp_client` and the main python script.  
+ - `start.sh`: This file starts the execution of the main python script, the one indicated in the `entry-file-name`.  
+ - `running.sh`: This file checks if the main python script is running.  
+ - `stop.sh`: This file stops the execution of the main python script.  

--- a/resources/operators/extraction/temperature_stub/entry-file-name
+++ b/resources/operators/extraction/temperature_stub/entry-file-name
@@ -1,0 +1,1 @@
+temperature_stub.py

--- a/resources/operators/extraction/temperature_stub/install.sh
+++ b/resources/operators/extraction/temperature_stub/install.sh
@@ -1,9 +1,1 @@
-#!/bin/bash
-paho_exist=$(pip3 list | grep -F paho-mqtt)
-if [ -z $paho_exist ]; then
- sudo apt-get update;
- sudo apt-get install -y python3;
- sudo apt-get install -y python3-pip;
- pip3 install paho-mqtt;
-fi
-echo "$1 = $2" > $3/connections.txt;
+../../mbp_client/install.sh

--- a/resources/operators/extraction/temperature_stub/mbp_client.py
+++ b/resources/operators/extraction/temperature_stub/mbp_client.py
@@ -1,0 +1,1 @@
+../../mbp_client/mbp_client.py

--- a/resources/operators/extraction/temperature_stub/running.sh
+++ b/resources/operators/extraction/temperature_stub/running.sh
@@ -1,7 +1,1 @@
-#!/bin/bash
-runningPID=$(ps -ef | grep temperature_stub.py | grep -v grep | awk '{print $2}');
-if [[ $runningPID != "" ]]; then
-   echo "true"; #is running
-else
-   echo "false"; # is not running
-fi
+../../mbp_client/running.sh

--- a/resources/operators/extraction/temperature_stub/start.sh
+++ b/resources/operators/extraction/temperature_stub/start.sh
@@ -1,3 +1,1 @@
-#!/bin/bash
-cd $1
-nohup python3 temperature_stub.py > start.log &
+../../mbp_client/start.sh

--- a/resources/operators/extraction/temperature_stub/stop.sh
+++ b/resources/operators/extraction/temperature_stub/stop.sh
@@ -1,2 +1,1 @@
-#!/bin/bash
-sudo kill -9 $(ps -ef | grep temperature_stub.py | grep -v grep | awk '{print $2}')
+../../mbp_client/stop.sh

--- a/resources/operators/extraction/temperature_stub/temperature_stub.py
+++ b/resources/operators/extraction/temperature_stub/temperature_stub.py
@@ -1,114 +1,40 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import sys, getopt
-import paho.mqtt.client as mqtt
-from datetime import datetime
+from mbp_client import MBPclient
+import sys
 import time
-import json
-import os, fnmatch
-from os.path import expanduser
 import random
 
-############################
-# MQTT Client
-############################
-class mqttClient(object):
-   hostname = 'localhost'
-   port = 1883
-   clientid = ''
+# default interval for sending data (seconds)
+INTERVAL_BETWEEN_SENDING_DATA = 15
 
-   def __init__(self, hostname, port, clientid):
-      self.hostname = hostname
-      self.port = port
-      self.clientid = clientid
+def main(argv):   
+    # instantiate the MBP client
+    mbp = MBPclient()
+    
+    # initialize the MBP client
+    mbp.connect()
 
-      # create MQTT client and set user name and password 
-      self.client = mqtt.Client(client_id=self.clientid, clean_session=True, userdata=None, protocol=mqtt.MQTTv31)
-      #client.username_pw_set(username="use-token-auth", password=mq_authtoken)
+    try:
+        # This loop ensures your code runs continuously, 
+        # for example, to read sensor values regularly at a given interval.
+        while True:
+            #############################
+            #### Your code goes here ####
+            value = random.choice([20.0, 20.5, 21.0, 22.0, 22.5, 25.5, 30.0, 30.1, 31.5, 29.9, 35.0])
+            #############################
+            
+            # send data to the MBP
+            mbp.send_data(value)
+            
+            # waits a time interval before sending new data
+            time.sleep(INTERVAL_BETWEEN_SENDING_DATA)
+    except:
+        error = sys.exc_info()
+        print ('Error:', str(error))
+    
+    # terminate the MBP client
+    mbp.finalize()
 
-      # set mqtt client callbacks
-      self.client.on_connect = self.on_connect
-
-   # The callback for when the client receives a CONNACK response from the server.
-   def on_connect(self, client, userdata, flags, rc):
-      print("[" + datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3] + "]: " + "ClientID: " + self.clientid + "; Connected with result code " + str(rc))
-
-   # publishes message to MQTT broker
-   def sendMessage(self, topic, msg):
-      self.client.publish(topic=topic, payload=msg, qos=0, retain=False)
-      print(msg)
-
-   # connects to MQTT Broker
-   def start(self):
-      self.client.connect(self.hostname, self.port, 60)
-
-      #runs a thread in the background to call loop() automatically.
-      #This frees up the main thread for other work that may be blocking.
-      #This call also handles reconnecting to the broker.
-      #Call loop_stop() to stop the background thread.
-      self.client.loop_start()
-
-
-############################
-# MAIN
-############################
-def main(argv):
-
-   configFileName = "connections.txt"
-   topics = []
-   brokerIps = []
-   configExists = False
-
-   hostname = 'localhost'
-   topic_pub = 'test'
-   
-   configFile = os.path.join(os.getcwd(), configFileName)
-   
-   while (not configExists):
-       configExists = os.path.exists(configFile)
-       time.sleep(1)
-
-   # BEGIN parsing file
-   fileObject = open (configFile)
-   fileLines = fileObject.readlines()
-   fileObject.close()
-
-   for line in fileLines:
-       pars = line.split('=')
-       topic = pars[0].strip('\n').strip()
-       ip = pars[1].strip('\n').strip()
-       topics.append(topic)
-       brokerIps.append(ip)
-
-   # END parsing file
-       
-   hostname = brokerIps [0]
-   topic_pub = topics [0]
-   topic_splitted = topic_pub.split('/')
-   component = topic_splitted [0]
-   component_id = topic_splitted [1]
-   
-   print("Connecting to: " + hostname + " pub on topic: " + topic_pub)
-   
-   # --- Begin start mqtt client
-   id = "id_%s" % (datetime.utcnow().strftime('%H_%M_%S'))
-   publisher = mqttClient(hostname, 1883, id)
-   publisher.start()
-
-   try:  
-      while True:
-         # messages in json format
-         # send message, topic: temperature
-         t = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
-         outputValue = random.choice([20.0, 20.5, 21.0, 22.0, 22.5, 25.5, 30.0, 30.1, 31.5, 29.9, 35.0])
-         msg_pub = {"component": component.upper(), "id": component_id, "value": "%f" % (outputValue) }
-         publisher.sendMessage (topic_pub, json.dumps(msg_pub))
-         #publisher.sendMessage (topic_pub, "42")
-
-         time.sleep(30)
-   except:
-      e = sys.exc_info()
-      print ("end due to: ", str(e))
-      
 if __name__ == "__main__":
    main(sys.argv[1:])

--- a/resources/operators/mbp_client/README.md
+++ b/resources/operators/mbp_client/README.md
@@ -1,0 +1,39 @@
+# How to use the MBP client
+
+The MBP client corresponds to a python script named [`mbp_client.py`](mbp_client.py). This script contains the logic to connect and communicated with the MBP. It abstracts a MQTT client and further configuration steps.
+
+To create your **own** python-based operator, you just need to import the MBP client in your customized python script:
+
+```
+  from mbp_client import MBPclient 
+```
+
+ An example of how to use the MBP client is provided in [`mbp_client_usage_example.py`](mbp_client_usage_example.py):  
+ 
+ - `mbp = MBPclient()` instantiates the MBP client.  
+ - `mbp.connect()` iniatializes and connect to the MBP.  
+ - `mbp.send_data(value)`sends sensor values to the MBP.  
+ - `mbp.finalize()` terminates the MBP client.  
+
+Furthermore, to manage the life cycle of the operator, we provide generic scripts that are executed by the MBP automatically: 
+ - [`install.sh`](install.sh)  
+ - [`start.sh`](start.sh)  
+ - [`running.sh`](running.sh)  
+ - [`stop.sh`](stop.sh)  
+
+These management scripts are required to be provided at the registration of an operator in the MBP, however, you still can change their content as you need for handle your operator.  
+
+ **However**, to let the MBP and the `start.sh` know the **entry point** of your operator, i.e., your main python script, you have to indicate its name in the content of `entry-file-name.txt`, for example, `mbp_client_usage_example.py`. This is **important** in case you provide several python scripts, so that the MBP can know which one should be started.
+
+# Summary: operator files list
+
+In summary, your operator should contain the following files:
+
+ - `mbp_client.py`: This python script contains the logic to connect and to communicate with the MBP. It abstracts a MQTT client and further configuration steps.  
+ - `entry-file-name`: This file contains solely the name of your main python script including its extension.  
+ - `<your-own-main-script>.py`: This file is your python script that uses the `mbp_client` to send (or receive) values to the MBP.  
+ - `<additional-script>.py` (0 or more): Further scripts that you might need to use in your main python script.  
+ - `install.sh`: This file installs the necessary libraries to run the `mbp_client` and the main python script.  
+ - `start.sh`: This file starts the execution of the main python script, the one indicated in the `entry-file-name`.  
+ - `running.sh`: This file checks if the main python script is running.  
+ - `stop.sh`: This file stops the execution of the main python script.  

--- a/resources/operators/mbp_client/entry-file-name
+++ b/resources/operators/mbp_client/entry-file-name
@@ -1,0 +1,1 @@
+mbp_client_usage_example.py

--- a/resources/operators/mbp_client/install.sh
+++ b/resources/operators/mbp_client/install.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+paho_exist=$(pip3 list | grep -F paho-mqtt)
+if [ -z "$paho_exist" ]; then
+ sudo apt-get update;
+ sudo apt-get install -y python3;
+ sudo apt-get install -y python3-pip;
+ pip3 install paho-mqtt;
+fi

--- a/resources/operators/mbp_client/running.sh
+++ b/resources/operators/mbp_client/running.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+DIR=`dirname $0`
+
+# checks if the stored PID at starting execution of the operator is still running
+if [ -f $DIR/pid.txt ]; then
+   PID=`cat $DIR/pid.txt`
+   if [ -n "$(ps -p  $PID -o pid=)" ]; then
+      echo "true"; #is running
+   else
+      sudo rm $DIR/pid.txt;
+      echo "false";
+   fi 
+else
+   echo "false"; # is not running
+fi

--- a/resources/operators/mbp_client/start.sh
+++ b/resources/operators/mbp_client/start.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+DIR=`dirname $0`
+cd $DIR
+# ---------Attention----------------
+# If you rename the main python file of the operator, update the content of the entry-file-name accordingly
+ENTRY_FILE_NAME=`cat $DIR/entry-file-name`
+#-----------------------------------
+
+nohup python3 $ENTRY_FILE_NAME > start.log &
+
+# output PID of last job running in background
+echo $! > pid.txt

--- a/resources/operators/mbp_client/stop.sh
+++ b/resources/operators/mbp_client/stop.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+DIR=`dirname $0`
+PID=`cat $DIR/pid.txt`
+sudo kill -9 $PID
+sudo rm $DIR/pid.txt


### PR DESCRIPTION
This PR will update the `mbp_client` folder and add **symbolic links** in operators folders to reuse the MBP client (`mbp_client.py`) and generic management scripts (`install.sh`, `start.sh`, `running.sh`, and `stop.sh`).  For now, these changes were carried out first only on the operator folder `/resources/operators/extraction/temperature_stub`.

Using symbolic links will avoid the existence of  **duplicates** in the MBP operators repository. 
However, if the generic management scripts are not enough for a specific operator, the symbolic links **should then be replaced** by concrete scripts in the respective operator folder.