### PR TITLE
Default unit for operators

### DIFF
--- a/src/main/resources/static/js/controllers/adapters/AdapterListController.js
+++ b/src/main/resources/static/js/controllers/adapters/AdapterListController.js
@@ -167,6 +167,7 @@ app.controller('AdapterListController',
                             //Extend request parameters for routines and parameters
                             return readRoutines(data.routineFiles)
                                 .then(function (response) {
+                                    data.unit = data.unit || "";
                                     data.routines = response;
                                     data.parameters = vm.parameters;
                                     return addAdapter(data);


### PR DESCRIPTION
Now it is no longer necessary to choose the option "No unit" from the suggestion list in case the operator does not need a unit; "no unit" is now the default.

Closes #337 