### PR TITLE
PR-357 Fix validation form of device creation

### DIFF
--- a/src/main/java/org/citopt/connde/domain/device/DeviceValidator.java
+++ b/src/main/java/org/citopt/connde/domain/device/DeviceValidator.java
@@ -70,13 +70,9 @@ public class DeviceValidator implements Validator {
 
             ValidationUtils.rejectIfEmptyOrWhitespace(
                     errors, "password", "device.password.empty",
-                    "You must inform a password or a RSA key.");
+                    "You must inform a password or include a SSH key pair.");
 
-            ValidationUtils.rejectIfEmptyOrWhitespace(
-                    errors, "rsaKey", "device.rsaKey.empty",
-                    "You must inform a password or a RSA key.");
         }
-
         //Retrieve fields that need to be of a certain format
         String ipAddress = device.getIpAddress();
 


### PR DESCRIPTION
Validation of a new device was trying to validate rsakey;
which is no longer propriety of device;
The information of empty field is already displayed on;
the password field so it is not needed again;

Print of how is displayed from now on:

<img width="634" alt="Captura de Tela 2020-08-21 às 12 31 16" src="https://user-images.githubusercontent.com/8583169/90886849-1d608900-e3ab-11ea-8b3c-2dfd68e0e498.png">
