### PR TITLE
Fix device registration with password 

### DIFF
--- a/src/main/java/org/citopt/connde/service/env_model/EnvironmentModelService.java
+++ b/src/main/java/org/citopt/connde/service/env_model/EnvironmentModelService.java
@@ -851,9 +851,12 @@ public class EnvironmentModelService {
         device.setUsername(deviceDetails.optString(MODEL_JSON_KEY_DEVICE_USERNAME, ""));
         device.setPassword(deviceDetails.optString(MODEL_JSON_KEY_DEVICE_PASSWORD, ""));
 
-        //Find key pair from repository and set it
-        KeyPair keyPair = keyPairRepository.findOne(deviceDetails.optString(MODEL_JSON_KEY_DEVICE_KEYPAIR));
-        device.setKeyPair(keyPair);
+        //Check if a key pair was provided
+        if(!deviceDetails.isNull(MODEL_JSON_KEY_DEVICE_KEYPAIR)){
+            //Get key pair from repository and set it
+            KeyPair keyPair = keyPairRepository.findOne(deviceDetails.optString(MODEL_JSON_KEY_DEVICE_KEYPAIR));
+            device.setKeyPair(keyPair);
+        }
 
         //Return final device object
         return device;


### PR DESCRIPTION
Fixes the issue with device registration in the environment model tool when a password is provided instead of a key pair.
Closes #335