### PR TITLE
Hiding the user management page

### DIFF
--- a/src/main/webapp/WEB-INF/views/index.html
+++ b/src/main/webapp/WEB-INF/views/index.html
@@ -138,16 +138,18 @@
             <div class="name" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style="font-size: 10px">
                 {{userData.firstName + " " + userData.lastName}}
             </div>
-            <div class="btn-group user-helper-dropdown" uib-dropdown="uib-dropdown" is-open="status.isopen">
+            <div class="btn-group user-helper-dropdown" uib-dropdown="uib-dropdown"
+                 is-open="status.isopen" ng-show="userData.isAdmin">
                 <!--<button class="dropdown-toggle pull-right">-->
-                <i class="material-icons" id="single-button" type="button" uib-dropdown-toggle="uib-dropdown-toggle"
+                <i class="material-icons" type="button" uib-dropdown-toggle="uib-dropdown-toggle"
                    ng-disabled="disabled">keyboard_arrow_down</i>
                 <!--</button>-->
                 <ul class="dropdown-menu pull-right" uib-dropdown-menu="uib-dropdown-menu" role="menu"
                     aria-labelledby="single-button">
                     <li>
                         <a href="view/users">
-                            <i class="material-icons">person</i>Users</a>
+                            <i class="material-icons">person</i>Users
+                        </a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
The user management page (../view/users) is now hidden in the frontend for non-admin users. Admin users can still access this page as before.

I did not add any internal restrictions for the user creation feature on this page, because this uses the same mechanic as the user registration on the landing page of the MBP. If we disallowed the user creation feature on the user management page, the user would still register a new user after logout and achieve exactly the same.

In my opinion, hiding the user management page in the frontend is already sufficient to solve the subsequently mentioned issues.

Closes #362
Closes #334