### PR TITLE
Improve parameters for operators #329

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -425,6 +425,12 @@ app.config(['$provide', '$routeProvider', '$locationProvider', '$resourceProvide
                             }
                         });
                     }],
+                    settings: ['SettingsService', function (SettingsService) {
+                        //Retrieve settings initially
+                        return SettingsService.getSettings().then(function (response) {
+                            return response.data;
+                        });
+                    }],
                     adapterList: ['CrudService', function (CrudService) {
                         return CrudService.fetchAllItems('adapters');
                     }],

--- a/src/main/resources/static/js/controllers/adapters/AdapterListController.js
+++ b/src/main/resources/static/js/controllers/adapters/AdapterListController.js
@@ -1,8 +1,8 @@
 /* global app */
 
 app.controller('AdapterListController',
-    ['$scope', '$controller', '$q', 'adapterList', 'adapterPreprocessing', 'addAdapter', 'deleteAdapter', 'FileReader', 'parameterTypesList', 'AdapterService', 'NotificationService',
-        function ($scope, $controller, $q, adapterList, adapterPreprocessing, addAdapter, deleteAdapter, FileReader, parameterTypesList, AdapterService, NotificationService) {
+    ['$scope', '$controller', '$q', 'adapterList', 'settings', 'adapterPreprocessing', 'addAdapter', 'deleteAdapter', 'FileReader', 'parameterTypesList', 'AdapterService', 'NotificationService',
+        function ($scope, $controller, $q, adapterList, settings, adapterPreprocessing, addAdapter, deleteAdapter, FileReader, parameterTypesList, AdapterService, NotificationService) {
             var vm = this;
 
             vm.dzServiceOptions = {
@@ -40,17 +40,6 @@ app.controller('AdapterListController',
 
             vm.dzMethods = {};
 
-            /**
-             * The device code parameter is necessary for every adapter.
-             * @type {{unit: string, name: string, type: string, mandatory: boolean}}
-             */
-            var deviceCodeParameter = {
-                name: "device_code",
-                type: "Text",
-                unit: "",
-                mandatory: true
-            };
-            vm.parameters = [deviceCodeParameter];
             vm.parameterTypes = parameterTypesList;
 
             /**
@@ -60,6 +49,21 @@ app.controller('AdapterListController',
                 //Validity check for parameter types
                 if (parameterTypesList.length < 1) {
                     NotificationService.notify("Could not load parameter types.", "error");
+                }
+
+                console.log("Checking broker location " + settings.brokerLocation);
+                if (settings.brokerLocation === "LOCAL_SECURE" || settings.brokerLocation === "REMOTE_SECURE") {
+                    /**
+                     * The device code parameter is necessary for every adapter, if a secured broker is used.
+                     * @type {{unit: string, name: string, type: string, mandatory: boolean}}
+                     */
+                    var deviceCodeParameter = {
+                        name: "device_code",
+                        type: "Text",
+                        unit: "",
+                        mandatory: true
+                    };
+                    vm.parameters = [deviceCodeParameter];
                 }
 
                 //Modify each adapter according to the preprocessing function (if provided)


### PR DESCRIPTION
Displaying of the 'device_code' parameter now depends on the settings. If a secured broker with OAuth2 is used, the device_code parameter is displayed when a new operator is added. Otherwise, this parameter is not visible.

Every time the operators list is loaded, the settings are requested from the backend. If the broker location in the settings equals 'LOCAL_SECURE' or 'REMOTE_SECURE', then the 'device_code' parameter is displayed. 

Resolves #329 