### PR TITLE
Replacement of bad line breaks

### DIFF
--- a/src/main/java/de/ipvs/as/mbp/domain/operator/Code.java
+++ b/src/main/java/de/ipvs/as/mbp/domain/operator/Code.java
@@ -1,7 +1,10 @@
 package de.ipvs.as.mbp.domain.operator;
 
-import org.apache.commons.codec.binary.Base64;
 import de.ipvs.as.mbp.util.CryptoUtils;
+import org.apache.commons.codec.binary.Base64;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class Code {
 
@@ -38,6 +41,29 @@ public class Code {
 
         //Update hash
         updateContentHash();
+    }
+
+    /**
+     * Returns the MIME prefix of the base64-encoded content, if available.
+     *
+     * @return The base64 prefix or an empty string in case there is none
+     */
+    public String getBase64MimePrefix() {
+        //Check if file is base64 encoded
+        if (!isBase64Encoded()) {
+            return "";
+        }
+
+        //Generate matcher for prefix using regular expression
+        Matcher matcher = Pattern.compile(REGEX_BASE64_PREFIX).matcher(this.content);
+
+        //Check for results
+        if (matcher.find()) {
+            return matcher.group();
+        }
+
+        //No results, return empty string
+        return "";
     }
 
     public String getHash() {

--- a/src/main/java/de/ipvs/as/mbp/domain/operator/Operator.java
+++ b/src/main/java/de/ipvs/as/mbp/domain/operator/Operator.java
@@ -5,12 +5,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import de.ipvs.as.mbp.domain.operator.parameters.Parameter;
 import de.ipvs.as.mbp.domain.user_entity.MBPEntity;
 import de.ipvs.as.mbp.domain.user_entity.UserEntity;
+import org.apache.commons.io.FilenameUtils;
 import org.springframework.data.annotation.Id;
 
 import javax.measure.quantity.Quantity;
 import javax.measure.unit.Unit;
 import javax.persistence.GeneratedValue;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 
 /**
@@ -18,6 +21,9 @@ import java.util.List;
  */
 @MBPEntity(createValidator = OperatorCreateValidator.class)
 public class Operator extends UserEntity {
+    //Whitelist of file extensions indicating files to which line break fixes are applied
+    private static final List<String> LBs_FIX_EXTENSION_WHITELIST = Arrays.asList("sh", "py", "md", "txt", "json",
+            "xml", "yaml", "js");
 
     @Id
     @GeneratedValue
@@ -109,5 +115,39 @@ public class Operator extends UserEntity {
     public Operator setParameters(List<Parameter> parameters) {
         this.parameters = parameters;
         return this;
+    }
+
+    /**
+     * Replaces all line breaks of certain routine files by LF line breaks in order to avoid incompatibilities when
+     * using files that were created on non-unix operating systems (Windows etc.). The replacement is only applied to
+     * files whose MIME type of the base64 encoding starts with "text" r files having a file extension that
+     * is part of the whitelist.
+     */
+    public void replaceLineBreaks() {
+        //Iterate over all routine files
+        for (Code file : routines) {
+            //Get MIME prefix for current file
+            String mimePrefix = file.getBase64MimePrefix();
+
+            //Get extension of current file
+            String fileExtension = FilenameUtils.getExtension(file.getName());
+
+            //Check if replacements may be applied to the routine file
+            if (!(mimePrefix.startsWith("data:text") || LBs_FIX_EXTENSION_WHITELIST.contains(fileExtension))) {
+                continue;
+            }
+
+            //Decode file content from base64
+            String decodedContent = new String(Base64.getDecoder().decode(file.getContent()));
+
+            //Replace all line breaks with LF line breaks
+            String fixedContent = decodedContent.replaceAll("\\r\\n", "\n").replaceAll("\\r", "\n");
+
+            //Encode file content to base64 again and prepend prefix
+            String encodedContent = mimePrefix + Base64.getEncoder().encodeToString(fixedContent.getBytes());
+
+            //Set fixed and encoded file content
+            file.setContent(encodedContent);
+        }
     }
 }

--- a/src/main/java/de/ipvs/as/mbp/service/settings/DefaultOperatorService.java
+++ b/src/main/java/de/ipvs/as/mbp/service/settings/DefaultOperatorService.java
@@ -157,6 +157,9 @@ public class DefaultOperatorService {
                     newOperator.addRoutine(newCode);
                 }
 
+                //Replace possibly bad line breaks in the operator files
+                newOperator.replaceLineBreaks();
+
                 //Insert new operator into repository
                 operatorRepository.insert(newOperator);
                 inserted = true;

--- a/src/main/java/de/ipvs/as/mbp/web/rest/RestOperatorController.java
+++ b/src/main/java/de/ipvs/as/mbp/web/rest/RestOperatorController.java
@@ -82,6 +82,9 @@ public class RestOperatorController {
             @RequestHeader("X-MBP-Access-Request") String accessRequestHeader,
             @ApiParam(value = "Page parameters", required = true) Pageable pageable,
             @RequestBody Operator operator) throws EntityAlreadyExistsException, EntityNotFoundException {
+        //Replace bad line breaks of plain text operator files
+        operator.replaceLineBreaks();
+
         // Save operator in the database
         Operator createdOperator = userEntityService.create(operatorRepository, operator);
         return ResponseEntity.ok(userEntityService.entityToEntityModel(createdOperator));


### PR DESCRIPTION
Added a first approach for replacing bad line breaks in operator files. In its current state, line breaks replacements are applied only to files whose MIME type in the base64 encoding starts with "data:text" or files that have a file extension that is part of a whitelist ("json", "xml", "js", "yaml", "py", "sh", "txt", "md"). For all files that qualify for the line breaks replacement, the MBP decodes the base64 string, replaces all line breaks by unix line breaks (LF) and encodes the string again to base64 when the user creates a new operator or adds a new default operator.

At the moment, this PR needs some further tests,

Closes #513