### PR TITLE
Enabled live data frequency configuration

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -10812,3 +10812,11 @@ html.ie11 .bs-searchbox .form-control {
     width: 90%;
 }
 
+/* Refresh interval input */
+.interval-input {
+    display: inline-block;
+    height: 25px;
+    font-size: smaller;
+    padding: 3px;
+    width: 50px;
+}

--- a/src/main/resources/static/js/controllers/components/ComponentDetailsController.js
+++ b/src/main/resources/static/js/controllers/components/ComponentDetailsController.js
@@ -357,7 +357,8 @@ app.controller('ComponentDetailsController',
                 vm.valueLogStats = {
                     loadingStart: loadingStart,
                     loadingFinish: loadingFinish,
-                    getStats: getStats
+                    getStats: getStats,
+                    interval: 120
                 };
             }
 
@@ -399,7 +400,8 @@ app.controller('ComponentDetailsController',
                     loadingStart: loadingStart,
                     loadingFinish: loadingFinish,
                     isUpdateable: isUpdateable,
-                    getData: retrieveComponentData
+                    getData: retrieveComponentData,
+                    interval: 15
                 };
             }
 

--- a/src/main/resources/static/js/controllers/devices/DeviceDetailsController.js
+++ b/src/main/resources/static/js/controllers/devices/DeviceDetailsController.js
@@ -49,6 +49,7 @@ app.controller('DeviceDetailsController',
                     operator.onMonitoringToggle = createMonitoringToggleFunction(compatibleOperators[i].id);
                     operator.getData = createDataRetrievalFunction(compatibleOperators[i].id);
                     operator.isUpdateable = createUpdateCheckFunction(compatibleOperators[i].id);
+                    operator.valueUpdateInterval = 15;
                     operator.getStats = createStatsRetrievalFunction(compatibleOperators[i].id);
                     operator.loadingLive = createLoadingFunctions(compatibleOperators[i].id, LIVE_CHART_SELECTOR_PREFIX,
                         "Loading live chart...");

--- a/src/main/resources/static/js/controllers/testing/TestingChartController.js
+++ b/src/main/resources/static/js/controllers/testing/TestingChartController.js
@@ -271,7 +271,8 @@ app.controller('TestingChartController',
                 vm.valueLogStats = {
                     loadingStart: loadingStart,
                     loadingFinish: loadingFinish,
-                    getStats: getStats
+                    getStats: getStats,
+                    interval: 120
                 };
             }
 
@@ -313,7 +314,8 @@ app.controller('TestingChartController',
                     loadingStart: loadingStart,
                     loadingFinish: loadingFinish,
                     isUpdateable: isUpdateable,
-                    getData: retrieveComponentData
+                    getData: retrieveComponentData,
+                    interval: 15
                 };
             }
 

--- a/src/main/resources/static/js/directives/charts/LiveChart.js
+++ b/src/main/resources/static/js/directives/charts/LiveChart.js
@@ -12,9 +12,6 @@ app.directive('liveChart', ['$timeout', '$interval', function ($timeout, $interv
     //Maximum number of elements that may be displayed in the chart
     const CHART_MAX_ELEMENTS = 20;
 
-    //Interval with that the chart data is refreshed (seconds)
-    const REFRESH_DELAY_SECONDS = 15;
-
     /**
      * Linking function, glue code
      *
@@ -174,12 +171,12 @@ app.directive('liveChart', ['$timeout', '$interval', function ($timeout, $interv
                     scope.loadingFinish();
 
                     //Visualize the time until the next refreshment
-                    runProgress(REFRESH_DELAY_SECONDS);
+                    runProgress(scope.interval);
                 });
             };
 
             //Create an interval that calls the update function on a regular basis
-            chartInterval = $interval(intervalFunction, 1000 * REFRESH_DELAY_SECONDS);
+            chartInterval = $interval(intervalFunction, 1000 * scope.interval);
 
             //Ensure that the interval is cancelled in case the user switches the page
             scope.$on('$destroy', function () {
@@ -207,7 +204,7 @@ app.directive('liveChart', ['$timeout', '$interval', function ($timeout, $interv
         function runProgress(time) {
             progressBar.stop(true).width(0).animate({
                 width: "100%",
-            }, 15 * 1000);
+            }, time * 1000);
         }
 
         //Watch the unit parameter
@@ -217,6 +214,16 @@ app.directive('liveChart', ['$timeout', '$interval', function ($timeout, $interv
             //Update chart if unit was changed
             cancelChartUpdate();
             initChart();
+            initChartUpdate();
+        });
+
+        //Watch the interval parameter
+        scope.$watch(function () {
+            return scope.interval;
+        }, function (newValue, oldValue) {
+            //Create new update interval with the new value
+            scope.interval = newValue;
+            cancelChartUpdate();
             initChartUpdate();
         });
 
@@ -245,7 +252,9 @@ app.directive('liveChart', ['$timeout', '$interval', function ($timeout, $interv
             //Function for updating the displayed data
             getData: '&getData',
             //Function that checks whether the chart is allowed to update its data
-            isUpdateable: '&isUpdateable'
+            isUpdateable: '&isUpdateable',
+            //Refresh interval
+            interval: '@interval'
         }
     };
 }]);

--- a/src/main/resources/static/js/directives/stats/ValueLogStats.js
+++ b/src/main/resources/static/js/directives/stats/ValueLogStats.js
@@ -8,9 +8,6 @@
  * @author Jan
  */
 app.directive('valueLogStats', ['$interval', function ($interval) {
-    //Time interval with that the value statistics are supposed to be refreshed
-    const REFRESH_DELAY_SECONDS = 60 * 2;
-
     /**
      * Linking function, glue code
      *
@@ -58,7 +55,7 @@ app.directive('valueLogStats', ['$interval', function ($interval) {
          */
         function createUpdateInterval() {
             //Create an interval that calls the update function on a regular basis
-            updateInterval = $interval(updateStats, 1000 * REFRESH_DELAY_SECONDS);
+            updateInterval = $interval(updateStats, 1000 * scope.interval);
 
             //Ensure that the interval is cancelled in case the user switches the page
             scope.$on('$destroy', function () {
@@ -82,6 +79,16 @@ app.directive('valueLogStats', ['$interval', function ($interval) {
         }, function (newValue, oldValue) {
             //Update statistics if unit was changed
             updateStats();
+        });
+
+        //Watch the interval parameter
+        scope.$watch(function () {
+            return scope.interval;
+        }, function (newValue, oldValue) {
+            //Create new update interval with the new value
+            scope.interval = newValue;
+            cancelUpdateInterval();
+            createUpdateInterval();
         });
 
         //Expose public api
@@ -159,6 +166,8 @@ app.directive('valueLogStats', ['$interval', function ($interval) {
             loadingFinish: '&loadingFinish',
             //Function for updating the value stats data
             getStats: '&getStats',
+            //Refresh interval
+            interval: '@interval'
         }
     };
 }]);

--- a/src/main/webapp/WEB-INF/views/templates/actuator-id.html
+++ b/src/main/webapp/WEB-INF/views/templates/actuator-id.html
@@ -163,7 +163,12 @@
                 </h2>
                 <ul class="header-dropdown m-r--5">
                     <li>
-                        <a ng-click="valueLogStatsApi.updateStats()" class="clickable">
+                        <input class="form-control interval-input" type="number"
+                               ng-model="componentDetailsCtrl.valueLogStats.interval"/>
+                        <span style="vertical-align: bottom;">s&nbsp;</span>
+                    </li>
+                    <li>
+                        <a ng-click="valueLogStatsApi.updateStats()" class="clickable" style="vertical-align: top;">
                             <i class="material-icons">refresh</i>
                         </a>
                     </li>
@@ -186,7 +191,8 @@
                                  loading-start="componentDetailsCtrl.valueLogStats.loadingStart()"
                                  loading-finish="componentDetailsCtrl.valueLogStats.loadingFinish()"
                                  get-stats="componentDetailsCtrl.valueLogStats.getStats(unit)"
-                                 unit="{{componentDetailsCtrl.displayUnit}}">
+                                 unit="{{componentDetailsCtrl.displayUnit}}"
+                                 interval="{{componentDetailsCtrl.valueLogStats.interval}}">
                 </value-log-stats>
                 <div style="height: 20px"></div>
                 <!--
@@ -206,13 +212,21 @@
             <div class="header">
             	<i class="material-icons" style="position: absolute; margin-top: 1px">live_tv</i>
                 <h2 style="margin-left: 35px;">Live Chart</h2>
+                <ul class="header-dropdown m-r--5">
+                    <li>
+                        <input class="form-control interval-input" type="number"
+                               ng-model="componentDetailsCtrl.liveChart.interval"/>
+                        <span style="vertical-align: bottom;">s&nbsp;</span>
+                    </li>
+                </ul>
             </div>
             <div class="body">
                 <live-chart loading-start="componentDetailsCtrl.liveChart.loadingStart()"
                             loading-finish="componentDetailsCtrl.liveChart.loadingFinish()"
                             get-data="componentDetailsCtrl.liveChart.getData(numberLogs, descending, unit)"
                             is-updateable="componentDetailsCtrl.liveChart.isUpdateable()"
-                            unit="{{componentDetailsCtrl.displayUnit}}">
+                            unit="{{componentDetailsCtrl.displayUnit}}"
+                            interval="{{componentDetailsCtrl.liveChart.interval}}">
                 </live-chart>
             </div>
         </div>

--- a/src/main/webapp/WEB-INF/views/templates/device-id.html
+++ b/src/main/webapp/WEB-INF/views/templates/device-id.html
@@ -174,8 +174,13 @@
                     </h2>
                     <ul class="header-dropdown m-r--5">
                         <li>
+                            <input class="form-control interval-input" type="number"
+                                   ng-model="operator.valueUpdateInterval"/>
+                            <span style="vertical-align: bottom;">s&nbsp;</span>
+                        </li>
+                        <li>
                             <a class="clickable"
-                               ng-click="operator.historicalChartApi.updateChart(); operator.valueLogStatsApi.updateStats();">
+                               ng-click="operator.historicalChartApi.updateChart(); operator.valueLogStatsApi.updateStats();"  style="vertical-align: top;">
                                 <i class="material-icons">refresh</i>
                             </a>
                         </li>
@@ -186,7 +191,7 @@
                             </a>
                         </li>-->
                         <li>
-                            <a class="clickable" data-toggle="collapse" data-target="#card-body-{{operator.id}}">
+                            <a class="clickable" data-toggle="collapse" data-target="#card-body-{{operator.id}}"  style="vertical-align: top;">
                                 <i class="material-icons">keyboard_arrow_down</i>
                             </a>
                         </li>
@@ -229,7 +234,8 @@
                                         loading-start="operator.loadingLive.start()"
                                         loading-finish="operator.loadingLive.finish()"
                                         get-data="operator.getData(numberLogs, descending, unit)"
-                                        unit="{{operator.displayUnit}}">
+                                        unit="{{operator.displayUnit}}"
+                                        interval="{{operator.valueUpdateInterval}}">
                             </live-chart>
                         </div>
                         <div role="tabpanel" class="tab-pane fade in active" id="historical-chart-{{operator.id}}">
@@ -246,7 +252,8 @@
                                              loading-start="operator.loadingStats.start()"
                                              loading-finish="operator.loadingStats.finish()"
                                              get-stats="operator.getStats(unit)"
-                                             unit="{{operator.displayUnit}}">
+                                             unit="{{operator.displayUnit}}"
+                                             interval="{{operator.valueUpdateInterval}}">
                             </value-log-stats>
                         </div>
                     </div>

--- a/src/main/webapp/WEB-INF/views/templates/sensor-id.html
+++ b/src/main/webapp/WEB-INF/views/templates/sensor-id.html
@@ -163,7 +163,12 @@
                 </h2>
                 <ul class="header-dropdown m-r--5">
                     <li>
-                        <a ng-click="valueLogStatsApi.updateStats()" class="clickable">
+                        <input class="form-control interval-input" type="number"
+                               ng-model="componentDetailsCtrl.valueLogStats.interval"/>
+                        <span style="vertical-align: bottom;">s&nbsp;</span>
+                    </li>
+                    <li>
+                        <a ng-click="valueLogStatsApi.updateStats()" class="clickable" style="vertical-align: top;">
                             <i class="material-icons">refresh</i>
                         </a>
                     </li>
@@ -186,7 +191,8 @@
                                  loading-start="componentDetailsCtrl.valueLogStats.loadingStart()"
                                  loading-finish="componentDetailsCtrl.valueLogStats.loadingFinish()"
                                  get-stats="componentDetailsCtrl.valueLogStats.getStats(unit)"
-                                 unit="{{componentDetailsCtrl.displayUnit}}">
+                                 unit="{{componentDetailsCtrl.displayUnit}}"
+                                 interval="{{componentDetailsCtrl.valueLogStats.interval}}">
                 </value-log-stats>
                 <div style="height: 20px"></div>
                 
@@ -205,13 +211,21 @@
             <div class="header">
             	<i class="material-icons" style="position: absolute; margin-top: 1px">live_tv</i>
                 <h2 style="margin-left: 35px;">Live Chart</h2>
+                <ul class="header-dropdown m-r--5">
+                    <li>
+                        <input class="form-control interval-input" type="number"
+                               ng-model="componentDetailsCtrl.liveChart.interval"/>
+                        <span style="vertical-align: bottom;">s&nbsp;</span>
+                    </li>
+                </ul>
             </div>
             <div class="body">
                 <live-chart loading-start="componentDetailsCtrl.liveChart.loadingStart()"
                             loading-finish="componentDetailsCtrl.liveChart.loadingFinish()"
                             get-data="componentDetailsCtrl.liveChart.getData(numberLogs, descending, unit)"
                             is-updateable="componentDetailsCtrl.liveChart.isUpdateable()"
-                            unit="{{componentDetailsCtrl.displayUnit}}">
+                            unit="{{componentDetailsCtrl.displayUnit}}"
+                            interval="{{componentDetailsCtrl.liveChart.interval}}">
                 </live-chart>
             </div>
         </div>

--- a/src/main/webapp/WEB-INF/views/templates/testing-tool-id.html
+++ b/src/main/webapp/WEB-INF/views/templates/testing-tool-id.html
@@ -1074,6 +1074,13 @@
                     <h2>
                         Live sensor values&nbsp;<i class="material-icons" style="color: red;">live_tv</i>
                     </h2>
+                    <ul class="header-dropdown m-r--5">
+                        <li>
+                            <input class="form-control interval-input" type="number"
+                                   ng-model="testingChartCtrl.liveChart.interval"/>
+                            <span style="vertical-align: bottom;">s&nbsp;</span>
+                        </li>
+                    </ul>
                 </div>
 
 
@@ -1082,7 +1089,8 @@
                                 loading-finish="testingChartCtrl.liveChart.loadingFinish()"
                                 get-data="testingChartCtrl.liveChart.getData(numberLogs, descending, '', sensor)"
                                 is-updateable="testingChartCtrl.liveChart.isUpdateable()"
-                                unit="{{testingChartCtrl.displayUnit}}">
+                                unit="{{testingChartCtrl.displayUnit}}"
+                                interval="{{testingChartCtrl.liveChart.interval}}">
                     </live-chart>
                 </div>
             </div>


### PR DESCRIPTION
Added frequency configuration possibility for value stats and live charts.

Properly tested on value stats, was unable to test on live charts.
Please test the implementation on live charts at sensors, actuators, devices (monitoring operators) and testing tool.