### PR TITLE
Stability fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,13 @@
             <artifactId>swagger2markup</artifactId>
             <version>1.3.3</version>
         </dependency>
+
+        <!--Cglib -->
+        <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib</artifactId>
+            <version>3.3.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/de/ipvs/as/mbp/SecurityConfiguration.java
+++ b/src/main/java/de/ipvs/as/mbp/SecurityConfiguration.java
@@ -17,12 +17,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
-/**
- * Security configuration
- *
- * @author Imeri Amil
- */
-
 @Configuration
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)

--- a/src/main/java/de/ipvs/as/mbp/security/RestAuthenticationEntryPoint.java
+++ b/src/main/java/de/ipvs/as/mbp/security/RestAuthenticationEntryPoint.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Component;
 
 /**
  * Entry point in case of unauthorized access.
- * @author Imeri Amil
  */
 @Component
 public class RestAuthenticationEntryPoint extends BasicAuthenticationEntryPoint {

--- a/src/main/java/de/ipvs/as/mbp/service/mqtt/MQTTService.java
+++ b/src/main/java/de/ipvs/as/mbp/service/mqtt/MQTTService.java
@@ -130,9 +130,8 @@ public class MQTTService {
      * @param brokerLocation The broker location to use
      * @param brokerAddress  The address of the broker to use
      * @throws MqttException In case of an error during execution of mqtt operations
-     * @throws IOException   In case of an I/O issue
      */
-    public void initialize(BrokerLocation brokerLocation, String brokerAddress) throws MqttException, IOException {
+    public void initialize(BrokerLocation brokerLocation, String brokerAddress) throws MqttException {
         //Disconnect the old mqtt client if already connected
         if ((mqttClient != null) && (mqttClient.isConnected())) {
             mqttClient.disconnectForcibly();


### PR DESCRIPTION
This PR contains two fixes that improve the stability of the MBP:

- After changing the settings on the settings page, the changes became effective only after restarting the MBP. This is now fixed.
- A dependency ("cglib") was somehow missing, leading to exceptions thrown by the Esper engine on the startup of the MBP. It's unclear whether this actually affected the MBP in any way.

Now it should be possible again to receive sensor values from VMs in the usual way. Furthermore, error message were improved.