### PR TITLE
Update to fix the RGB LED operator scripts

### DIFF
--- a/resources/operators/control/LK-led-rgb_raspberry-pi/LK-led-rgb_raspberry-pi.py
+++ b/resources/operators/control/LK-led-rgb_raspberry-pi/LK-led-rgb_raspberry-pi.py
@@ -4,7 +4,7 @@ import sys
 import paho.mqtt.client as mqtt
 from datetime import datetime
 import time
-from neopixel import *
+from rpi_ws281x import *
 import os
 import argparse
 

--- a/resources/operators/control/LK-led-rgb_raspberry-pi/README.md
+++ b/resources/operators/control/LK-led-rgb_raspberry-pi/README.md
@@ -6,11 +6,12 @@ This folder contains operator scripts to control a [Linkerkit LED RGB](http://ww
 
 - a Raspberry Pi.  
 - (optional) a [LK base board](http://www.linkerkit.de/index.php?title=LK-Base-RB_2).  
-- a [LK LED RGB actuator](http://www.linkerkit.de/images/2/24/LK-LED-RGB_17-05-2017.pdf) plugged to the `digital pin GPIO12` of the Raspberry Pi or of the LK base board.
+- a [LK LED RGB actuator](http://www.linkerkit.de/images/2/24/LK-LED-RGB_17-05-2017.pdf) or any WS281X compatible LEDs like Neopixels plugged to the `digital pin GPIO12` of the Raspberry Pi or `D12` of the LK base board.
+- since this uses PWM, which is by default also used for audio on the PI we first need to disable PWM audio like so: https://pypi.org/project/rpi-ws281x/
 
 ## Operator files 
 
-- `LK-led-rgb_raspberry-pi.py`: This python script contains a MQTT client, which subscribes to a configured topic on the MBP. **To be fixed**: It is important to note that python2 is used to execute this python script.
+- `LK-led-rgb_raspberry-pi.py`: This python script contains a MQTT client, which subscribes to a configured topic on the MBP.
  
 - `install.sh`: This file installs the necessary libraries to run the python script.
  

--- a/resources/operators/control/LK-led-rgb_raspberry-pi/install.sh
+++ b/resources/operators/control/LK-led-rgb_raspberry-pi/install.sh
@@ -6,4 +6,5 @@ if [ -z $paho_exist ]; then
  sudo apt-get install -y python3-pip;
  pip3 install paho-mqtt;
 fi
+pip3 install rpi_ws281x;
 echo "$1 = $2" > $3/connections.txt;

--- a/resources/operators/control/LK-led-rgb_raspberry-pi/start.sh
+++ b/resources/operators/control/LK-led-rgb_raspberry-pi/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 cd $1
-nohup python2 LK-led-rgb_raspberry-pi.py > start.log &
+nohup sudo python3 LK-led-rgb_raspberry-pi.py > start.log &


### PR DESCRIPTION
Updated old Neopixels library to newer rpi_ws281x. The scripts are now Python3 compatible.
Updated readme accordingly. Also added link to show how to disable PWM audio, since this can interfere with the PWM control of the LEDs.