### PR TITLE
Small fix for the analog reader for use with an 8 channel ADC

### DIFF
--- a/resources/operators/mbp_client/mbp_analog_reader.py
+++ b/resources/operators/mbp_client/mbp_analog_reader.py
@@ -15,8 +15,8 @@ class AnalogInputReader(object):
     self.adc_channel = adc_channel
 
   def read_adc(self):
-    # read SPI data from MCP3004 chip, 4 possible adc’s (0 thru 3)
-    if ((self.adc_channel > 3) or (self.adc_channel < 0)):
+    # read SPI data from MCP3008 chip, 8 possible adc’s (0 thru 7)
+    if ((self.adc_channel > 7) or (self.adc_channel < 0)):
       return -1
     r = self.spi.xfer2([1,8+self.adc_channel <<4,0])
     adcout = ((r[1] &3) <<8)+r[2]


### PR DESCRIPTION
The current analog reader only supports the MCP3004 4 Channel ADC used in the small version of the LinkerBase Board. This limits the usage to only 2 analog devices. The full-sized LinkerBase Board uses the MCP3008 8 Channel ADC allowing for 4 analog devices. This updated updates the code to also support the 8 Channel ADC 