### PR TITLE
Determine component type by topic

### DIFF
--- a/src/main/java/de/ipvs/as/mbp/domain/component/ComponentCreateValidator.java
+++ b/src/main/java/de/ipvs/as/mbp/domain/component/ComponentCreateValidator.java
@@ -2,14 +2,11 @@ package de.ipvs.as.mbp.domain.component;
 
 import de.ipvs.as.mbp.error.EntityValidationException;
 import de.ipvs.as.mbp.repository.ActuatorRepository;
-import de.ipvs.as.mbp.repository.ComponentRepository;
 import de.ipvs.as.mbp.repository.SensorRepository;
 import de.ipvs.as.mbp.service.validation.ICreateValidator;
 import de.ipvs.as.mbp.util.Validation;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
-import sun.util.locale.LanguageTag;
 
 /**
  * Creation validator for component entities.

--- a/src/main/java/de/ipvs/as/mbp/service/receiver/ValueLogReceiverArrivalHandler.java
+++ b/src/main/java/de/ipvs/as/mbp/service/receiver/ValueLogReceiverArrivalHandler.java
@@ -35,7 +35,7 @@ class ValueLogReceiverArrivalHandler implements MqttCallback {
     private static final String JSON_KEY_VALUE = "value";
 
     //Pattern for retrieving component types from message topics
-    private static final Pattern COMPONENT_TYPES_PATTERN = Pattern.compile("^([a-zA-Z0-9]+)/.+");
+    private static final Pattern COMPONENT_TYPES_PATTERN = Pattern.compile("^([a-zA-Z0-9_-]+)/.+");
 
     //Set of observers
     private Set<ValueLogReceiverObserver> observerSet;

--- a/src/main/java/de/ipvs/as/mbp/service/receiver/ValueLogReceiverArrivalHandler.java
+++ b/src/main/java/de/ipvs/as/mbp/service/receiver/ValueLogReceiverArrivalHandler.java
@@ -20,6 +20,8 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * then added to the value log repository.
@@ -29,9 +31,11 @@ import java.util.Set;
 class ValueLogReceiverArrivalHandler implements MqttCallback {
 
     //JSON key names
-    private static final String JSON_KEY_COMPONENT_TYPE = "component";
     private static final String JSON_COMPONENT_ID = "id";
     private static final String JSON_KEY_VALUE = "value";
+
+    //Pattern for retrieving component types from message topics
+    private static final Pattern COMPONENT_TYPES_PATTERN = Pattern.compile("^([a-zA-Z0-9]+)/.+");
 
     //Set of observers
     private Set<ValueLogReceiverObserver> observerSet;
@@ -97,11 +101,14 @@ class ValueLogReceiverArrivalHandler implements MqttCallback {
             //Create a json object from the message
             JSONObject json = new JSONObject(message);
 
-            //Extract all required data from the message and add it to a new value log object
+            //Create new empty value log
             ValueLog valueLog = new ValueLog();
 
-            String componentType = json.getString(JSON_KEY_COMPONENT_TYPE);
+            //Retrieve component ID from message
             String componentID = json.getString(JSON_COMPONENT_ID);
+
+            //Extract component type from topic under which the message was published
+            String componentType = extractComponentType(topic);
 
             //Check component ID for validity
             if (!isComponentIDValid(componentID, componentType)) {
@@ -166,13 +173,13 @@ class ValueLogReceiverArrivalHandler implements MqttCallback {
         }
 
         //Check component type
-        if (componentType.toLowerCase().equals(new Actuator().getComponentTypeName())) {
+        if (componentType.equalsIgnoreCase(new Actuator().getComponentTypeName())) {
             //Component is actuator, check if component exists
             return actuatorRepository.existsById(componentID);
-        } else if (componentType.toLowerCase().equals(new Sensor().getComponentTypeName())) {
+        } else if (componentType.equalsIgnoreCase(new Sensor().getComponentTypeName())) {
             //Component is sensor, check if component exists
             return sensorRepository.existsById(componentID);
-        } else if (componentType.toLowerCase().equals(new MonitoringComponent().getComponentTypeName())) {
+        } else if (componentType.equalsIgnoreCase(new MonitoringComponent().getComponentTypeName())) {
             //Component is monitoring component, create monitoring component object
             MonitoringComponent monitoringComponent = new MonitoringComponent(componentID);
 
@@ -192,5 +199,25 @@ class ValueLogReceiverArrivalHandler implements MqttCallback {
         }
 
         return false;
+    }
+
+    /**
+     * Extracts the type of a component from the topic under which the component published a message.
+     *
+     * @param topic The topic to evaluate
+     * @return The determined component type or null, if invalid
+     */
+    private String extractComponentType(String topic) {
+        //Sanity checks
+        if ((topic == null) || topic.isEmpty()) return null;
+
+        //Try to extract the component type by using the regular expression pattern
+        Matcher matcher = COMPONENT_TYPES_PATTERN.matcher(topic);
+
+        //Check if the matches of interest could be found
+        if (!matcher.find()) return null;
+
+        //Return group result containing the component type
+        return matcher.group(1);
     }
 }


### PR DESCRIPTION
ValueLogReceiver now uses the message topic in order to determine the component type and not the deprecated `componentType` field of the messages anymore.

Closes #615 